### PR TITLE
:1234: cast threshold to number

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -6,7 +6,7 @@ module.exports = {
   JSON_FILE_URL: process.env.JSON_FILE_URL,
   INPUT_DIR: './input',
   // percentage the records can be of previous before erroring
-  THRESHOLD: process.env.CHANGE_THRESHOLD || 0.99,
+  THRESHOLD: Number(process.env.CHANGE_THRESHOLD) || 0.99,
   // cron style job, default to 7am
   UPDATE_SCHEDULE: process.env.UPDATE_SCHEDULE || '0 7 * * *',
 


### PR DESCRIPTION
Numeric values held in the vault are converted to a string when mapped through to Rancher.
This change ensures the CHANGE_THRESHOLD is a number within the application.